### PR TITLE
Node.js actions are deprecated

### DIFF
--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: "Set up Python 3.11"
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python environment"
         uses: ./.github/actions/setup-python
@@ -18,7 +18,7 @@ jobs:
         uses: ./.github/actions/build-app
 
       - name: "Upload dci binaries"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dci_binaries
           path: dist/
@@ -28,7 +28,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python environment"
         uses: ./.github/actions/setup-python
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Set up Python environment"
         uses: ./.github/actions/setup-python
@@ -88,5 +88,5 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
-          skip_existing: true
+          skip-existing: true
           verbose: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           ($changelog | Select-Object -First $last_change -Skip 1) -join "`n" | Out-File .\RELEASENOTES.md
 
       - name: "Create Release"
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@ 4634c16e79c963813287e889244c50009e7f0981
         env:
           GITHUB_TOKEN: ${{ secrets.REL_TOKEN }}
         with:


### PR DESCRIPTION
Node.js 16 actions are deprecated. 

Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

No official release for: `softprops/action-gh-release` there is issue:
softprops/action-gh-release#410

As workaround: [406 (comment)](https://github.com/softprops/action-gh-release/pull/406#issuecomment-1934635958)
