### PR TITLE
Update GitHub release action in CI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           ($changelog | Select-Object -First $last_change -Skip 1) -join "`n" | Out-File .\RELEASENOTES.md
 
       - name: "Create Release"
-        uses: softprops/action-gh-release@4634c16e79c963813287e889244c50009e7f0981
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.REL_TOKEN }}
         with:


### PR DESCRIPTION
Updated the version of the 'softprops/action-gh-release' action used in our CI workflow to v2. This is to fix issues we've been facing in the previous version, and ensure consistency in our release process.